### PR TITLE
Expose Rest Config

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -19,6 +19,7 @@ import (
 type K8s struct {
 	Clientset        coreClient.Interface
 	MetricsClientSet *metricsClient.Clientset
+	RestConfig       *restClient.Config
 }
 
 var logEnabled bool
@@ -36,6 +37,7 @@ func NewK8s() (*K8s, error) {
 		}
 
 		config, err := restClient.InClusterConfig()
+		client.RestConfig = config
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +63,7 @@ func NewK8s() (*K8s, error) {
 	}
 	flag.Parse()
 	config, err := cmdClient.BuildConfigFromFlags("", *kubeconfig)
+	client.RestConfig = config
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This will help us to run remote commands against a pod:

```
	exec, err := remotecommand.NewSPDYExecutor(ac.k8s.RestConfig, "POST", req.URL())
```